### PR TITLE
Automatically open frequency up during calibration.

### DIFF
--- a/streams/streams.cc
+++ b/streams/streams.cc
@@ -78,6 +78,7 @@ void Process(uint16_t* cv) {
         &frequency);
     if (ui.calibrating()) {
       gain = 0;
+      frequency = 65535;
     }
     dac.Write(i, cv_scaler.ScaleGain(i, gain));
     pwm.Write(i, 65535 - frequency);


### PR DESCRIPTION
If, before attempting a calibration, the MOD knob was fully counter-clockwise, entering calibration mode would result in almost no audible signal on the outputs. During calibration, the mod knob doesn't react. 
It might be better to simply overwrite the MOD knob entirely so that the filter remains open during the calibration procedure.