### PR TITLE
Yarns disallows sequence transpose if UI is in a recording mode

### DIFF
--- a/yarns/global.h
+++ b/yarns/global.h
@@ -1,0 +1,10 @@
+#ifndef YARNS_GLOBAL_H_
+#define YARNS_GLOBAL_H_
+
+#include "yarns/ui.h"
+
+using namespace yarns;
+
+extern Ui ui;
+
+#endif // YARNS_GLOBAL_H_

--- a/yarns/part.cc
+++ b/yarns/part.cc
@@ -326,8 +326,7 @@ void Part::ClockSequencer() {
 
   if (step.has_note()) {
     int16_t note = step.note();
-    //TODO check if ANY part is recording, not just this one
-    if (pressed_keys_.size() && !seq_recording_) {
+    if (pressed_keys_.size() && !yarns::ui.is_recording()) {
       // When we play a monophonic sequence, we can make the guess that root
       // note = first note.
       // But this is not the case when we are playing several sequences at the

--- a/yarns/part.cc
+++ b/yarns/part.cc
@@ -39,7 +39,6 @@
 #include "yarns/voice.h"
 
 #include "yarns/global.h"
-Ui ui;
 
 namespace yarns {
 
@@ -323,6 +322,8 @@ void Part::StopSequencerArpeggiatorNotes() {
     InternalNoteOff(note);
   }
 }
+
+Ui ui;
 
 void Part::ClockSequencer() {
   const SequencerStep& step = seq_.step[seq_step_];

--- a/yarns/part.cc
+++ b/yarns/part.cc
@@ -326,6 +326,7 @@ void Part::ClockSequencer() {
 
   if (step.has_note()) {
     int16_t note = step.note();
+    //TODO check if ANY part is recording, not just this one
     if (pressed_keys_.size() && !seq_recording_) {
       // When we play a monophonic sequence, we can make the guess that root
       // note = first note.

--- a/yarns/part.cc
+++ b/yarns/part.cc
@@ -37,6 +37,8 @@
 #include "yarns/midi_handler.h"
 #include "yarns/resources.h"
 #include "yarns/voice.h"
+#include "yarns/settings.h"
+#include "yarns/ui.h"
 
 namespace yarns {
 
@@ -326,7 +328,7 @@ void Part::ClockSequencer() {
 
   if (step.has_note()) {
     int16_t note = step.note();
-    if (pressed_keys_.size() && !yarns::ui.is_recording()) {
+    if (pressed_keys_.size() && !Ui::ui_.is_recording()) {
       // When we play a monophonic sequence, we can make the guess that root
       // note = first note.
       // But this is not the case when we are playing several sequences at the

--- a/yarns/part.cc
+++ b/yarns/part.cc
@@ -37,7 +37,6 @@
 #include "yarns/midi_handler.h"
 #include "yarns/resources.h"
 #include "yarns/voice.h"
-#include "yarns/settings.h"
 #include "yarns/ui.h"
 
 namespace yarns {

--- a/yarns/part.cc
+++ b/yarns/part.cc
@@ -37,7 +37,9 @@
 #include "yarns/midi_handler.h"
 #include "yarns/resources.h"
 #include "yarns/voice.h"
-#include "yarns/ui.h"
+
+#include "yarns/global.h"
+Ui ui;
 
 namespace yarns {
 
@@ -327,7 +329,7 @@ void Part::ClockSequencer() {
 
   if (step.has_note()) {
     int16_t note = step.note();
-    if (pressed_keys_.size() && !Ui::ui_.is_recording()) {
+    if (pressed_keys_.size() && !ui.is_recording()) {
       // When we play a monophonic sequence, we can make the guess that root
       // note = first note.
       // But this is not the case when we are playing several sequences at the

--- a/yarns/ui.h
+++ b/yarns/ui.h
@@ -101,8 +101,6 @@ class Ui {
   Ui() { }
   ~Ui() { }
   
-  static Ui ui_;
-
   void Init();
   void Poll();
   void PollFast() {

--- a/yarns/ui.h
+++ b/yarns/ui.h
@@ -132,6 +132,11 @@ class Ui {
   inline bool factory_testing() const {
     return mode_ == UI_MODE_FACTORY_TESTING;
   }
+  inline bool is_recording() const {
+    return  mode_ == UI_MODE_RECORDING ||
+            mode_ == UI_MODE_OVERDUBBING ||
+            mode_ == UI_MODE_PUSH_IT_SELECT_NOTE;
+  }
   inline uint8_t calibration_voice() const { return calibration_voice_; }
   inline uint8_t calibration_note() const { return calibration_note_; }
   

--- a/yarns/ui.h
+++ b/yarns/ui.h
@@ -101,6 +101,8 @@ class Ui {
   Ui() { }
   ~Ui() { }
   
+  static Ui ui_;
+
   void Init();
   void Poll();
   void PollFast() {

--- a/yarns/yarns.cc
+++ b/yarns/yarns.cc
@@ -74,12 +74,12 @@ void SysTick_Handler() {
   // UI polling and LED refresh at 1kHz.
   static uint8_t counter;
   if ((++counter & 7) == 0) {
-    ui.Poll();
+    Ui::ui_.Poll();
     system_clock.Tick();
   }
   // When there is audio sources, lower the display refresh rate to 8kHz.
   if (has_audio_sources) {
-    ui.PollFast();
+    Ui::ui_.PollFast();
   }
   
   // Try to read some MIDI input if available.
@@ -111,10 +111,10 @@ void SysTick_Handler() {
   
   // In calibration mode, overrides the DAC outputs with the raw calibration
   // table values.
-  if (ui.calibrating()) {
-    const Voice& voice = multi.voice(ui.calibration_voice());
-    cv[ui.calibration_voice()] = voice.calibration_dac_code(
-        ui.calibration_note());
+  if (Ui::ui_.calibrating()) {
+    const Voice& voice = multi.voice(Ui::ui_.calibration_voice());
+    cv[Ui::ui_.calibration_voice()] = voice.calibration_dac_code(
+        Ui::ui_.calibration_note());
   } else if (midi_handler.calibrating()) {
     const Voice& voice = multi.voice(midi_handler.calibration_voice());
     cv[midi_handler.calibration_voice()] = voice.calibration_dac_code(
@@ -122,7 +122,7 @@ void SysTick_Handler() {
   }
   
   // In UI testing mode, overrides the GATE values with timers
-  if (ui.factory_testing()) {
+  if (Ui::ui_.factory_testing()) {
     gate[0] = (factory_testing_counter % 800) < 400;
     gate[1] = (factory_testing_counter % 400) < 200;
     gate[2] = (factory_testing_counter % 266) < 133;
@@ -155,19 +155,22 @@ void TIM1_UP_IRQHandler(void) {
     multi.RefreshInternalClock();
   } else if (dac.channel() == 1) {
     if (!has_audio_sources) {
-      ui.PollFast();
+      Ui::ui_.PollFast();
     }
   }
 }
 
 }
 
+Ui Ui::ui_ = Ui();
+
 void Init() {
   sys.Init();
   
   settings.Init();
   multi.Init();
-  ui.Init();
+  // ui = Ui::ui_;
+  Ui::ui_.Init();
 
   // Load multi 0 on boot.
   storage_manager.LoadMulti(0);
@@ -184,13 +187,13 @@ void Init() {
 int main(void) {
   Init();
   while (1) {
-    ui.DoEvents();
+    Ui::ui_.DoEvents();
     midi_handler.ProcessInput();
     multi.ProcessInternalClockEvents();
     multi.RenderAudio();
     if (midi_handler.factory_testing_requested()) {
       midi_handler.AcknowledgeFactoryTestingRequest();
-      ui.StartFactoryTesting();
+      Ui::ui_.StartFactoryTesting();
     }
   }
 }

--- a/yarns/yarns.cc
+++ b/yarns/yarns.cc
@@ -44,7 +44,6 @@ using namespace stmlib;
 
 Dac dac;
 GateOutput gate_output;
-Ui ui;
 MidiIO midi_io;
 System sys;
 
@@ -169,7 +168,6 @@ void Init() {
   
   settings.Init();
   multi.Init();
-  // ui = Ui::ui_;
   Ui::ui_.Init();
 
   // Load multi 0 on boot.


### PR DESCRIPTION
Previous behavior was to only disallow transpose on a part if that same part was recording.  This change disallows transpose on all parts if any part is recording, by checking the UI mode instead of the part.

This change also makes the UI a global variable, which may be undesirable.  Any feedback welcome!