### PR TITLE
Yarns sequencer doesn't transpose if a part is recording

### DIFF
--- a/yarns/multi.h
+++ b/yarns/multi.h
@@ -205,6 +205,9 @@ class Multi {
         Stop();
       }
       part_[part].StartRecording();
+      for (uint8_t i = 0; i < num_active_parts_; ++i) {
+        part_[i].SetMultiIsRecording(true);
+      }
       recording_ = true;
     }
   }
@@ -212,6 +215,9 @@ class Multi {
   void StopRecording(uint8_t part) {
     if (recording_) {
       part_[part].StopRecording();
+      for (uint8_t i = 0; i < num_active_parts_; ++i) {
+        part_[i].SetMultiIsRecording(false);
+      }
       recording_ = false;
     }
   }

--- a/yarns/part.cc
+++ b/yarns/part.cc
@@ -326,7 +326,7 @@ void Part::ClockSequencer() {
 
   if (step.has_note()) {
     int16_t note = step.note();
-    if (pressed_keys_.size() && !seq_recording_) {
+    if (pressed_keys_.size() && !multi_is_recording_) {
       // When we play a monophonic sequence, we can make the guess that root
       // note = first note.
       // But this is not the case when we are playing several sequences at the

--- a/yarns/part.h
+++ b/yarns/part.h
@@ -345,6 +345,10 @@ class Part {
     release_latched_keys_on_next_note_on_ = true;
   }
   
+  inline void SetMultiIsRecording(bool b) {
+    multi_is_recording_ = b;
+  }
+
   void set_siblings(bool has_siblings) {
     has_siblings_ = has_siblings;
   }
@@ -402,6 +406,8 @@ class Part {
   
   bool has_siblings_;
   
+  bool multi_is_recording_;
+
   DISALLOW_COPY_AND_ASSIGN(Part);
 };
 


### PR DESCRIPTION
Thanks for the feedback here! https://github.com/pichenettes/eurorack/pull/15#issuecomment-418121061

This is a shot at implementing it.  I also considered giving `Part` a pointer back to `Multi`, but I'm guessing that is being avoided for separation-of-concerns reasons.