### PR TITLE
Yarns parts don't accept input if another part is recording on the same channel

### DIFF
--- a/yarns/part.h
+++ b/yarns/part.h
@@ -271,6 +271,9 @@ class Part {
   }
   
   inline bool accepts(uint8_t channel) const {
+    if (!(transposable_ || seq_recording_)) {
+      return false;
+    }
     return midi_.channel == 0x10 || midi_.channel == channel;
   }
   


### PR DESCRIPTION
This leverages the new `transposable_` to address a case similar to #17.