### PR TITLE
Initialize previous_position_ prior to use in rings/elements resonators.

### DIFF
--- a/elements/dsp/resonator.cc
+++ b/elements/dsp/resonator.cc
@@ -56,6 +56,7 @@ void Resonator::Init() {
   set_brightness(0.5f);
   set_damping(0.3f);
   set_position(0.999f);
+  previous_position_ = 0.0f;
   set_resolution(kMaxModes);
   
   bow_signal_ = 0.0f;

--- a/rings/dsp/resonator.cc
+++ b/rings/dsp/resonator.cc
@@ -49,6 +49,7 @@ void Resonator::Init() {
   set_brightness(0.5f);
   set_damping(0.3f);
   set_position(0.999f);
+  previous_position_ = 0.0f;
   set_resolution(kMaxModes);
 }
 


### PR DESCRIPTION
I use Andrew Belt's VCV Rack, and users have found issues with Southpole Annuli and Audible Instruments Resonator starting up pegged at +5V.  The Elements clone has a similar bug, but I've not made heavy use of the module, so I've not been bitten there.  I found that both use resonator.cc, and that has an uninitialized instance variable previous_position_ that is referenced prior to any assignment.  Here is an attempt at a fix, and so far it's working for me, but I'm not a DSP guru, and I can't be sure that zero is an appropriate initial value.  Any thoughts here?

Thanks.