### PR TITLE
add extra row to chords in plaits

### DIFF
--- a/plaits/dsp/engine/chord_engine.cc
+++ b/plaits/dsp/engine/chord_engine.cc
@@ -37,18 +37,18 @@ namespace plaits {
 using namespace std;
 using namespace stmlib;
 
-const float chords[kChordNumChords][kChordNumNotes] = {
-  { 0.00f, 0.01f, 11.99f, 12.00f },  // OCT
-  { 0.00f, 7.01f,  7.00f, 12.00f },  // 5
-  { 0.00f, 5.00f,  7.00f, 12.00f },  // sus4
-  { 0.00f, 3.00f,  7.00f, 12.00f },  // m
-  { 0.00f, 3.00f,  7.00f, 10.00f },  // m7
-  { 0.00f, 3.00f, 10.00f, 14.00f },  // m9
-  { 0.00f, 3.00f, 10.00f, 17.00f },  // m11
-  { 0.00f, 2.00f,  9.00f, 16.00f },  // 69
-  { 0.00f, 4.00f, 11.00f, 14.00f },  // M9
-  { 0.00f, 4.00f,  7.00f, 11.00f },  // M7
-  { 0.00f, 4.00f,  7.00f, 12.00f },  // M
+const float chords[kChordNumChords][kChordNumNotes + 1] = {
+  { 0.00f, 0.01f, 11.99f, 12.00f, 0.00f },  // OCT
+  { 0.00f, 7.01f,  7.00f, 12.00f, 0.00f },  // 5
+  { 0.00f, 5.00f,  7.00f, 12.00f, 0.00f },  // sus4
+  { 0.00f, 3.00f,  7.00f, 12.00f, 0.00f },  // m
+  { 0.00f, 3.00f,  7.00f, 10.00f, 0.00f },  // m7
+  { 0.00f, 3.00f, 10.00f, 14.00f, 0.00f },  // m9
+  { 0.00f, 3.00f, 10.00f, 17.00f, 0.00f },  // m11
+  { 0.00f, 2.00f,  9.00f, 16.00f, 0.00f },  // 69
+  { 0.00f, 4.00f, 11.00f, 14.00f, 0.00f },  // M9
+  { 0.00f, 4.00f,  7.00f, 11.00f, 0.00f },  // M7
+  { 0.00f, 4.00f,  7.00f, 12.00f, 0.00f },  // M
 };
 
 void ChordEngine::Init(BufferAllocator* allocator) {


### PR DESCRIPTION
Fixes issue #26 by adding an extra row of 0s to the `chords` array.
I'm not a big fan of the `+ 1` floating next to `kChordNumNotes`, but I didn't want to change the code too much.