### PR TITLE
Fix compiler warnings

### DIFF
--- a/braids/settings.h
+++ b/braids/settings.h
@@ -323,7 +323,7 @@ class Settings {
   }
   
   inline int32_t pitch_transposition() const {
-    int32_t t = data_.pitch_range == PITCH_RANGE_LFO ? -36 << 7 : 0;
+    int32_t t = data_.pitch_range == PITCH_RANGE_LFO ? (unsigned)-36 << 7 : 0;
     t += (static_cast<int32_t>(data_.pitch_octave) - 2) * 12 * 128;
     return t;
   }
@@ -351,7 +351,7 @@ class Settings {
     return metadata_[setting];
   }
 
-  static const Setting setting_at_index(int16_t index) {
+  static const Setting& setting_at_index(int16_t index) {
     return settings_order_[index];
   }
   

--- a/frames/poly_lfo.h
+++ b/frames/poly_lfo.h
@@ -72,7 +72,7 @@ class PolyLfo {
   inline const uint8_t* color() const {
     return &color_[0];
   }
-  inline const uint16_t dac_code(uint8_t index) const {
+  inline uint16_t dac_code(uint8_t index) const {
     return dac_code_[index];
   }
   static uint32_t FrequencyToPhaseIncrement(int32_t frequency);

--- a/stages/delay_line_16_bits.h
+++ b/stages/delay_line_16_bits.h
@@ -65,7 +65,7 @@ class DelayLine16Bits {
     }
   }
   
-  inline const float Read(float delay) const {
+  inline float Read(float delay) const {
     MAKE_INTEGRAL_FRACTIONAL(delay)
     size_t read_ptr = (write_ptr_ + delay_integral) % max_delay;
     float a = static_cast<float>(line_[read_ptr]) / 32768.0f;


### PR DESCRIPTION
Just a couple minor fixes for things detected in macOS clang.
