### PR TITLE
Fix various typos

### DIFF
--- a/marbles/clock_self_patching_detector.h
+++ b/marbles/clock_self_patching_detector.h
@@ -26,7 +26,7 @@
 //
 // Class for detecting if the t1 or t2 gate outputs are patched into the X
 // clock input. This is done by comparing the number of synchronous transitions
-// on the gate ouputs and the clock input. A small margin of error is allowed
+// on the gate outputs and the clock input. A small margin of error is allowed
 // because of acquisition delays.
 
 #ifndef MARBLES_CLOCK_SELF_PATCHING_DETECTOR_H_

--- a/marbles/makefile
+++ b/marbles/makefile
@@ -32,7 +32,7 @@ FAMILY         = f4xx
 APPLICATION_LARGE = TRUE
 BOOTLOADER        = marbles_bootloader
 
-# Prefered upload command
+# Preferred upload command
 UPLOAD_COMMAND  = upload_combo_jtag_erase_first
 
 # Packages to build

--- a/marbles/ramp/slave_ramp.h
+++ b/marbles/ramp/slave_ramp.h
@@ -24,7 +24,7 @@
 //
 // -----------------------------------------------------------------------------
 //
-// A ramp that follows a mater ramp through division/multiplication.
+// A ramp that follows a master ramp through division/multiplication.
 
 #ifndef MARBLES_RAMP_SLAVE_RAMP_H_
 #define MARBLES_RAMP_SLAVE_RAMP_H_

--- a/plaits/dsp/engine/additive_engine.cc
+++ b/plaits/dsp/engine/additive_engine.cc
@@ -83,7 +83,7 @@ void AdditiveEngine::UpdateAmplitudes(
     
     // Warning about the following line: this is not a proper LP filter because
     // of the normalization. But in spite of its strange working, this line
-    // turns out ot be absolutely essential.
+    // turns out to be absolutely essential.
     //
     // I have tried both normalizing the LP-ed spectrum, and LP-ing the
     // normalized spectrum, and both of them cause more annoyances than this

--- a/plaits/dsp/oscillator/string_synth_oscillator.h
+++ b/plaits/dsp/oscillator/string_synth_oscillator.h
@@ -72,8 +72,8 @@ class StringSynthOscillator {
     frequency *= 8.0f;
     
     // Deal with very high frequencies by shifting everything 1 or 2 octave
-    // down: Instead of playing the 1nd harmonic of a 8kHz wave, we play the
-    // second harmonic of a 4kHz wave.
+    // down: Instead of playing the 1st harmonic of a 8kHz wave, we play the
+    // 2nd harmonic of a 4kHz wave.
     size_t shift = 0;
     while (frequency > 0.5f) {
       shift += 2;

--- a/plaits/makefile
+++ b/plaits/makefile
@@ -32,7 +32,7 @@ FAMILY         = f37x
 APPLICATION_LARGE = TRUE
 BOOTLOADER        = plaits_bootloader
 
-# Prefered upload command
+# Preferred upload command
 UPLOAD_COMMAND  = upload_combo_jtag_erase_first
 
 # Packages to build

--- a/plaits/ui.h
+++ b/plaits/ui.h
@@ -131,7 +131,7 @@ class Ui {
   
   int active_engine_;
   
-  float cv_c1_;  // For calibraiton
+  float cv_c1_;  // For calibration
   
   static const CvAdcChannel normalized_channels_[kNumNormalizedChannels];
     

--- a/rings/dsp/string_synth_part.cc
+++ b/rings/dsp/string_synth_part.cc
@@ -168,7 +168,7 @@ const float chords[kMaxStringSynthPolyphony][kNumChords][kMaxChordSize] = {
 // Original chord table:
 // - wider, occupies more room in the spectrum.
 // - minimum number of note changes between adjacent chords.
-// - consistant with the chord table used for the sympathetic strings model.
+// - consistent with the chord table used for the sympathetic strings model.
 const float chords[kMaxStringSynthPolyphony][kNumChords][kMaxChordSize] = {
   {
     { -24.0f, -12.0f, 0.0f, 0.01f, 0.02f, 11.99f, 12.0f, 24.0f },

--- a/stages/makefile
+++ b/stages/makefile
@@ -32,7 +32,7 @@ FAMILY         = f37x
 APPLICATION_LARGE = TRUE
 BOOTLOADER        = stages_bootloader
 
-# Prefered upload command
+# Preferred upload command
 UPLOAD_COMMAND  = upload_combo_jtag_erase_first
 
 # Packages to build

--- a/streams/cv_scaler.h
+++ b/streams/cv_scaler.h
@@ -57,7 +57,7 @@ class CvScaler {
   
   bool can_calibrate() const;
   
-  // This class owns the calibration data and is reponsible for removing
+  // This class owns the calibration data and is responsible for removing
   // offsets.
   inline int16_t audio_sample(uint8_t channel) const {
     int32_t value = static_cast<int32_t>(

--- a/tides2/makefile
+++ b/tides2/makefile
@@ -32,7 +32,7 @@ FAMILY         = f37x
 APPLICATION_LARGE = TRUE
 BOOTLOADER        = tides2_bootloader
 
-# Prefered upload command
+# Preferred upload command
 UPLOAD_COMMAND  = upload_combo_jtag_erase_first
 
 # Packages to build

--- a/yarns/layout_configurator.cc
+++ b/yarns/layout_configurator.cc
@@ -25,7 +25,7 @@
 // -----------------------------------------------------------------------------
 //
 // Class monitoring a sequence of notes on the MIDI input and automatically
-// chosing the best layout
+// choosing the best layout
 
 #include "yarns/layout_configurator.h"
 #include "yarns/multi.h"

--- a/yarns/layout_configurator.h
+++ b/yarns/layout_configurator.h
@@ -25,7 +25,7 @@
 // -----------------------------------------------------------------------------
 //
 // Class monitoring a sequence of notes on the MIDI input and automatically
-// chosing the best layout
+// choosing the best layout
 
 #ifndef YARNS_LAYOUT_CONFIGURATOR_H_
 #define YARNS_LAYOUT_CONFIGURATOR_H_

--- a/yarns/multi.cc
+++ b/yarns/multi.cc
@@ -65,7 +65,7 @@ void Multi::Init(bool reset_calibration) {
   recording_ = false;
   
   // Put the multi in a usable state. Even if these settings will later be
-  // overriden with some data retrieved from Flash (presets).
+  // overridden with some data retrieved from Flash (presets).
   settings_.clock_tempo = 120;
   settings_.clock_swing = 0;
   settings_.clock_input_division = 1;


### PR DESCRIPTION
Found via `codespell  -q 3 -L fof,som`